### PR TITLE
add production flag because we don't want to install dev dependencies…

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-npm install
+npm install --production
 
 # Build static assets
 gulp build


### PR DESCRIPTION
… when deploying